### PR TITLE
[WIP] Bezier fit to a spring

### DIFF
--- a/iconimation/src/error.rs
+++ b/iconimation/src/error.rs
@@ -16,3 +16,11 @@ pub enum SpringBuildError {
     #[error("Damping must be >= 0")]
     InvalidDamping,
 }
+
+#[derive(Debug, Error)]
+pub enum SpringFitError {
+    #[error("Did not reach equilibrium by {0:.3}")]
+    NoEquilibrium(f64),
+    #[error("We hit equilibrium immediately; no curve to smooth")]
+    ImmediateEquilibrium,
+}

--- a/iconimation/src/lib.rs
+++ b/iconimation/src/lib.rs
@@ -5,6 +5,7 @@ pub mod debug_pen;
 pub mod error;
 mod shape_pen;
 pub mod spring;
+pub mod spring_fit;
 
 use std::f64::consts::PI;
 

--- a/iconimation/src/spring.rs
+++ b/iconimation/src/spring.rs
@@ -65,7 +65,11 @@ impl Spring {
         Self::new_internal(1.0, 380.0)
     }
 
-    /// Compute for a new time, such as a new frame
+    /// Compute for a new time, such as a new frame.
+    ///
+    /// Does not appear to give the right value unless walked frame by frame. For example,
+    /// passing in the animated value at time 0 and asking what the value is at some arbitrary
+    /// value doesn't give you the desired curve whereas walking frame by frame does.
     ///
     /// See:
     /// * [DynamicAnimation::doAnimationFrame](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/com/android/internal/dynamicanimation/animation/DynamicAnimation.java;l=663-693;drc=b7d26a383dbb3c7fa3f276d8ad1afdac5bb5443f)
@@ -133,11 +137,11 @@ impl Spring {
 /// <https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/com/android/internal/dynamicanimation/animation/SpringForce.java;l=261-307;drc=b7d26a383dbb3c7fa3f276d8ad1afdac5bb5443f>
 #[derive(Debug, Copy, Clone)]
 pub struct AnimatedValue {
-    value: f64,
-    value_type: AnimatedValueType,
-    velocity: f64,
-    final_value: f64,
-    time: f64,
+    pub(crate) value: f64,
+    pub(crate) value_type: AnimatedValueType,
+    pub(crate) velocity: f64,
+    pub(crate) final_value: f64,
+    pub(crate) time: f64,
 }
 
 impl AnimatedValue {

--- a/iconimation/src/spring_fit.rs
+++ b/iconimation/src/spring_fit.rs
@@ -1,0 +1,185 @@
+//! Fit a bezier to a springed animation.
+//!
+//! Intended use is to convert a spring animation to bezier ease(s) for environments that
+//! don't have spring, e.g. native Lottie players or css-only web animation.
+
+use kurbo::{fit_to_bezpath, BezPath, CurveFitSample, ParamCurveFit, Point, Vec2};
+
+use crate::{
+    error::SpringFitError,
+    spring::{AnimatedValue, Spring},
+};
+
+struct SpringFitter {
+    spring: Spring,
+    frames: Vec<AnimatedValue>,
+    frame_rate: f64,
+    last_frame: f64,
+}
+
+impl SpringFitter {
+    pub fn new(
+        spring: Spring,
+        animation: AnimatedValue,
+        frame_rate: f64,
+    ) -> Result<Self, SpringFitError> {
+        let mut current = animation;
+        let mut frame = 0.0;
+        let mut frame_values = vec![animation];
+        while !current.is_at_equilibrium() {
+            frame += 1.0;
+            let time = frame / frame_rate;
+            current = spring.update(time, current);
+            frame_values.push(current);
+            if time > Self::IMPLAUSIBLY_LONG_TIME {
+                return Err(SpringFitError::NoEquilibrium(time));
+            }
+        }
+
+        if frame < 1.0 {
+            return Err(SpringFitError::ImmediateEquilibrium);
+        }
+        Ok(Self {
+            spring,
+            frames: frame_values,
+            frame_rate,
+            last_frame: frame,
+        })
+    }
+
+    /// (frame, value) point for the specified frame
+    fn frame_value(&self, frame: f64) -> Point {
+        let frame_before = frame.floor();
+
+        let value = if frame < Self::TANGENT_FRAME_OFFSET {
+            *self.frames.first().unwrap()
+        } else if frame + Self::TANGENT_FRAME_OFFSET > self.last_frame {
+            *self.frames.last().unwrap()
+        } else if (frame - frame_before).abs() < Self::FRAME_EPSILON {
+            // just take the exact value
+            self.frames[frame_before as usize]
+        } else {
+            // Try to advance from frame before to target
+            let frame_before: AnimatedValue = self.frames[frame_before as usize];
+            self.spring.update(frame / self.frame_rate, frame_before)
+        };
+        (frame, value.value).into()
+    }
+
+    const IMPLAUSIBLY_LONG_TIME: f64 = 300.0;
+    const TANGENT_FRAME_OFFSET: f64 = 0.05;
+    const FRAME_EPSILON: f64 = 0.001;
+}
+
+/// In a simple spring from A => B there are no cusps which simplifies things
+impl ParamCurveFit for SpringFitter {
+    fn sample_pt_tangent(&self, t: f64, _sign: f64) -> CurveFitSample {
+        let (p, tangent) = self.sample_pt_deriv(t);
+        CurveFitSample { p, tangent }
+    }
+
+    fn sample_pt_deriv(&self, t: f64) -> (Point, Vec2) {
+        let frame = t * self.last_frame;
+
+        // Calculate prev, curr, next
+        let prev = self.frame_value(frame - Self::TANGENT_FRAME_OFFSET);
+        let curr = self.frame_value(frame);
+        let next = self.frame_value(frame + Self::TANGENT_FRAME_OFFSET);
+
+        // average prev->curr and curr->next
+        let deriv = ((curr - prev) + (next - curr)) / 2.0;
+        (curr, deriv)
+    }
+
+    fn break_cusp(&self, _range: std::ops::Range<f64>) -> Option<f64> {
+        None
+    }
+}
+
+/// Produce a bezier equivalent to animating the provided value with a spring until it hits equilibrium.
+pub fn spring_to_bezier(
+    spring: Spring,
+    animation: AnimatedValue,
+    frame_rate: f64,
+) -> Result<BezPath, SpringFitError> {
+    let fitter = SpringFitter::new(spring, animation, frame_rate)?;
+    Ok(fit_to_bezpath(&fitter, 0.1))
+}
+
+#[cfg(test)]
+mod tests {
+    use kurbo::ParamCurveFit;
+    use kurbo::PathEl;
+    use kurbo::Point;
+
+    use crate::spring::AnimatedValueType;
+    use crate::spring_fit::SpringFitter;
+
+    use super::spring_to_bezier;
+    use super::AnimatedValue;
+    use super::Spring;
+
+    fn round(p: &mut Point, digits: u32) {
+        let factor = 10u32.pow(digits) as f64;
+        p.x = (p.x * factor).round() / factor;
+        p.y = (p.y * factor).round() / factor;
+    }
+
+    #[test]
+    fn spring_draw_tangents() {
+        let spring = Spring::expressive_spatial();
+        let animated_value = AnimatedValue::new(0.0, 100.0, AnimatedValueType::Scale);
+        let fitter = SpringFitter::new(spring, animated_value, 60.0).unwrap();
+
+        let mut frame = 0.0;
+        let mut last = animated_value;
+        while frame < fitter.last_frame {
+            last = spring.update(frame / fitter.frame_rate, last);
+            let (p, tan) = fitter.sample_pt_deriv(frame / fitter.last_frame);
+            let tan = tan.normalize() * 2.0;
+            let p0 = p;
+            let p1 = p + tan;
+            eprintln!("<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"blue\" stroke-width=\"0.2\" stroke-opacity=\"50%\" />",
+                p0.x, p0.y, p1.x, p1.y);
+            frame += 0.5;
+        }
+
+        let mut frame = 0.0;
+        let mut last = animated_value;
+        while frame < fitter.last_frame {
+            last = spring.update(frame / fitter.frame_rate, last);
+            eprintln!(
+                "<circle cx=\"{frame:.2}\" cy=\"{:.2}\" r=\"0.5\" />",
+                last.value
+            );
+            frame += 1.0;
+        }
+    }
+
+    #[test]
+    fn spring_to_bezier_scale_0_to_100() {
+        let spring = Spring::expressive_spatial();
+        let animated_value = AnimatedValue::new(0.0, 100.0, AnimatedValueType::Scale);
+
+        // Let's scale from nothing to something at 60fps
+        let mut bez = spring_to_bezier(spring, animated_value, 60.0).unwrap();
+        for el in bez.elements_mut() {
+            match el {
+                PathEl::ClosePath => (),
+                PathEl::MoveTo(p) | PathEl::LineTo(p) => {
+                    round(p, 2);
+                }
+                PathEl::QuadTo(c, p) => {
+                    round(c, 2);
+                    round(p, 2);
+                }
+                PathEl::CurveTo(c1, c2, p) => {
+                    round(c1, 2);
+                    round(c2, 2);
+                    round(p, 2);
+                }
+            }
+        }
+        eprintln!("{}", bez.to_svg().replace(" C", "\nC"));
+    }
+}


### PR DESCRIPTION
Example of tangents so calculated (blue lines at each half-frame), https://codepen.io/rs42/pen/JjzpPyP
Example of fit curve, https://codepen.io/rs42/pen/jOJZNPa
Example of a quick hand-written fit using 2 cubics, https://codepen.io/rs42/pen/JjzpPyP

Context: we'd like to fit a small # of beziers to the curve produced by a spring so we can use the spring in places that have bezier easing and no spring function.

My intuition is that this is more cubics than we actually need. Fiddling fit_to_bezpath will eventually destroy the result but does not seem to let me get a good result with fewer cubics as I might have hoped. Most likely I just screwed up ParamCurveFit, haven't used it before and I"m not completely confidet I understood it correctly.